### PR TITLE
[ASME] Fix to match Arduino SAMD PR #24

### DIFF
--- a/hardware/AMEL/samd/variants/AMEL_SmartEverything/variant.h
+++ b/hardware/AMEL/samd/variants/AMEL_SmartEverything/variant.h
@@ -160,6 +160,10 @@ static const uint8_t A5  = PIN_A5 ;
 #define PIN_SPI_MISO         (22u)
 #define PIN_SPI_MOSI         (23u)
 #define PIN_SPI_SCK          (24u)
+#define PERIPH_SPI           sercom4
+#define PAD_SPI_TX           SPI_PAD_2_SCK_3
+#define PAD_SPI_RX           SERCOM_RX_PAD_0
+
 #define PIN_SPI_SS           (25u)
 
 static const uint8_t SS	  = PIN_SPI_SS ;
@@ -174,6 +178,8 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
 
 #define PIN_WIRE_SDA         (20u)
 #define PIN_WIRE_SCL         (21u)
+#define PERIPH_WIRE          sercom3
+#define WIRE_IT_HANDLER      SERCOM3_Handler
 
 /*
  * USB


### PR DESCRIPTION
Fix to match https://github.com/arduino/ArduinoCore-samd/pull/24

Merging this patch shouldn't bring any impact if PR #24 is not merged in Arduino side (only few #defines).
