### PR TITLE
please review the changes for the pins array

### DIFF
--- a/hardware/AMEL/samd/variants/AMEL_SmartEverything/variant.cpp
+++ b/hardware/AMEL/samd/variants/AMEL_SmartEverything/variant.cpp
@@ -97,7 +97,7 @@ const PinDescription g_APinDescription[]=
  * | 21         | SCL              |  PA23  | SCL             | EIC/EXTINT[7]                        PTC/X[11] *SERCOM3/PAD[1] SERCOM5/PAD[1] TC4/WO[1] TCC0/WO[5]
  * +------------+------------------+--------+-----------------+--------------------------------------------------------------------------------------------------------
  */
-  { PORTA, 22, PIO_SERCOM, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_6 }, // SDA: SERCOM3/PAD[0]
+  { PORTA, 22, PIO_SERCOM, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // SDA: SERCOM3/PAD[0]
   { PORTA, 23, PIO_SERCOM, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_7 }, // SCL: SERCOM3/PAD[1]
 
 /*
@@ -231,8 +231,8 @@ const PinDescription g_APinDescription[]=
  * | 49         | IO_EXT_INT       |  PB06  |                 | EXTINT[6] AIN[14] Y[12]
  * +------------+------------------+--------+-----------------+--------------------------------------------------------------------------------------------------------
  */
-  { PORTA, 13, PIO_PWM, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM), No_ADC_Channel, PWM2_CH1, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // TCC2/WO[1]
-  { PORTB, 06, PIO_ANALOG, PIN_ATTR_ANALOG, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_6 }, // ADC/AIN[14]
+ { PORTA, 13, PIO_DIGITAL, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // I2C extender reset
+ { PORTB, 06, PIO_EXTINT, PIN_ATTR_EXTINT, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_6 }, // I2C extender interrupt
       
 /*
  * +------------+------------------+--------+-----------------+--------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
@aethaniel  @speirano   sorry I wrongly created the branch on the ameltech repo and not on my.
Fixed error in pins array declaration for IoExtender
Adjust the I2C SDA pin declaration to avoid unwanted interrupt
