### PR TITLE
Make SmartEverything Basic examples show in Arduino IDE 1.6.6 File > Examples menu

### DIFF
--- a/hardware/AMEL/samd/libraries/SME_basic/SME_basic.h
+++ b/hardware/AMEL/samd/libraries/SME_basic/SME_basic.h
@@ -1,0 +1,1 @@
+// This file allows the SmartEverything Basic examples to appear in the Arduino IDE 1.6.6 File > Examples menu.


### PR DESCRIPTION
Adding a dummy .h file to the SME_basic library folder allows the
SmartEverything Basic examples to appear in the Arduino IDE 1.6.6 **File >
Examples** menu and fixes the invalid library warnings shown when Library
Manager or Boards Manager is opened with an AMEL-Tech board selected.
